### PR TITLE
[Draft] Change Method Representation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ authors = [
 dependencies = [
     "pydantic>=2.4",
     "numpy",
+    "pyyaml",
+    "types-PyYAML",
 ]
 
 [build-system]
@@ -27,6 +29,9 @@ where = ["."]  # list of folders that contain the packages (["."] by default)
 include = ["stjames", "stjames.*"]  # package names should match these glob patterns (["*"] by default)
 exclude = []  # exclude packages matching these glob patterns (empty by default)
 namespaces = false  # to disable scanning PEP 420 namespaces (true by default)
+
+[tool.setuptools.package-data]
+"*" = ["*.yaml"]
 
 [tool.ruff]
 line-length = 160

--- a/stjames/method.py
+++ b/stjames/method.py
@@ -1,5 +1,4 @@
 from .base import Base
-from typing import ClassVar
 
 
 class Method(Base):

--- a/stjames/method.py
+++ b/stjames/method.py
@@ -1,49 +1,176 @@
-from .base import LowercaseStrEnum
+from .base import Base
+from typing import ClassVar
 
 
-class Method(LowercaseStrEnum):
-    #### Hartree–Fock:
-    HARTREE_FOCK = "hf"
-    HF3C = "hf-3c"
+class Method(Base):
+    name: str
+    aliases: list[str] = []
+    display_name: str
+    corrections_allowed: bool = True
+    basis_sets_allowed: bool = True
 
-    #### DFT:
-    # LDA
-    LSDA = "lsda"
+    _psi4_name: str | None = None
+    _pyscf_name: str | None = None
+    _terachem_name: str | None = None
 
-    # local GGA
-    PBE = "pbe"
-    BLYP = "blyp"
-    BP86 = "bp86"
-    B97D3 = "b97-d3"
-    B973C = "b97-3c"
+    @property
+    def psi4_name(self):
+        return self._psi4_name if self._psi4_name is not None else self.name
 
-    # mGGA
-    R2SCAN = "r2scan"
-    TPSS = "tpss"
-    M06L = "m06l"
+    @property
+    def pyscf_name(self):
+        return self._pyscf_name if self._pyscf_name is not None else self.name
 
-    # hybrid GGA
-    PBE0 = "pbe0"
-    B3LYP = "b3lyp"
-    B3PW91 = "b3pw91"
-    B97MV = "b97m_v"
+    @property
+    def terachem_name(self):
+        return self._terachem_name if self._terachem_name is not None else self.name
 
-    # hybrid mGGA
-    TPSS0 = "tpss0"
-    M06 = "m06"
-    M062X = "m062x"
 
-    # range-separated
-    CAMB3LYP = "camb3lyp"
-    WB97XD = "wb97x_d"
-    WB97XD3 = "wb97x_d3"
-    WB97XV = "wb97x_v"
-    WB97MV = "wb97m_v"
+HARTREE_FOCK = Method(
+    name="hf",
+    display_name="HF",
+)
 
-    # ML methods
-    AIMNET2_WB97MD3 = "aimnet2_wb97md3"
-    AIMNET2_B973C = "aimnet2_b973c"
+HF3C = Method(
+    name="hf_3c",
+    display_name="HF-3c",
+)
 
-    # xTB methods
-    GFN1_XTB = "gfn1_xtb"
-    GFN2_XTB = "gfn2_xtb"
+PBE = Method(
+    name="pbe",
+    display_name="PBE",
+)
+
+B973C = Method(
+    name="b97_3c",
+    aliases=["b973c", "b97-3c"],
+    display_name="B97-3c",
+    corrections_allowed=False,
+    basis_sets_allowed=False,
+)
+
+R2SCAN = Method(
+    name="r2scan",
+    display_name="r2SCAN",
+)
+
+R2SCAN3C = Method(
+    name="r2scan_3c",
+    aliases=["r2scan3c", "r2scan-3c"],
+    display_name="r2SCAN-3c",
+    corrections_allowed=False,
+    basis_sets_allowed=False,
+)
+
+TPSS = Method(
+    name="tpss",
+    display_name="TPSS",
+)
+
+M06L = Method(
+    name="m06l",
+    display_name="M06-L",
+)
+
+PBE0 = Method(
+    name="pbe0",
+    display_name="PBE0",
+)
+
+B3LYP = Method(
+    name="b3lyp",
+    display_name="B3LYP",
+)
+
+TPSSH = Method(
+    name="tpssh",
+    display_name="TPSSh",
+)
+
+M06 = Method(
+    name="m06",
+    display_name="M06",
+)
+
+M062X = Method(
+    name="m062x",
+    display_name="M06-2X",
+)
+
+CAMB3LYP = Method(
+    name="camb3lyp",
+    display_name="CAM-B3LYP",
+)
+
+WB97XD3 = Method(
+    name="wb97x_d3",
+    aliases=["wb97xd3", "wb97x-d3"],
+    display_name="ωB97X-D3",
+    corrections_allowed=False,
+)
+
+WB97XV = Method(
+    name="wb97x_v",
+    aliases=["wb97xv", "wb97x-v"],
+    display_name="ωB97X-V",
+    corrections_allowed=False,
+)
+
+WB97MV = Method(
+    name="wb97m_v",
+    aliases=["wb97mv", "wb97m-v"],
+    display_name="ωB97M-V",
+    corrections_allowed=False,
+)
+
+WB97MD3BJ = Method(
+    name="wb97m_d3bj",
+    aliases=["wb97md3bj", "wb97m-d3bj"],
+    display_name="ωB97M-D3BJ",
+    corrections_allowed=False,
+)
+
+WB97X3C = Method(
+    name="wb97x_3c",
+    aliases=["wb97x3c", "wb97x-3c"],
+    display_name="ωB97X-3c",
+    corrections_allowed=False,
+    basis_sets_allowed=False,
+)
+
+DSDBLYPD3BJ = Method(
+    name="dsd_blyp_d3bj",
+    aliases=["dsdblypd3bj", "dsdblyp_d3bj", "dsd-blyp-d3bj"],
+    display_name="DSD-BLYP-D3BJ",
+    corrections_allowed=False,
+)
+
+
+AIMNET2_WB97MD3 = Method(
+    name="aimnet2_wb97md3",
+    display_name="AIMNet2 ωB97M-D3BJ",
+    corrections_allowed=False,
+    basis_sets_allowed=False,
+)
+
+GFN1_XTB = Method(
+    name="gfn1_xtb",
+    display_name="GFN1-xTB",
+    corrections_allowed=False,
+    basis_sets_allowed=False,
+)
+
+GFN2_XTB = Method(
+    name="gfn2_xtb",
+    display_name="GFN2-xTB",
+    corrections_allowed=False,
+    basis_sets_allowed=False,
+)
+
+GFN_FF = Method(
+    name="gfnff",
+    alises=["gfn_ff"],
+    display_name="GFN-FF",
+    corrections_allowed=False,
+    basis_sets_allowed=False,
+)

--- a/stjames/method_data.yaml
+++ b/stjames/method_data.yaml
@@ -1,0 +1,70 @@
+HARTREE_FOCK:
+  name: hf
+  display_name: HF
+  corrections_allowed: true
+  basis_sets_allowed: true
+HF3C:
+  name: hf_3c
+  display_name: HF-3c
+  corrections_allowed: false
+  basis_sets_allowed: false
+PBE:
+  name: pbe
+  display_name: PBE
+  corrections_allowed: true
+  basis_sets_allowed: true
+B973C:
+  name: b97_3c
+  display_name: B97-3c
+  corrections_allowed: false
+  basis_sets_allowed: false
+R2SCAN:
+  name: r2scan
+  display_name: r2SCAN
+  corrections_allowed: true
+  basis_sets_allowed: true
+R2SCAN3C:
+  name: r2scan_3c
+  display_name: r2SCAN-3c
+  corrections_allowed: false
+  basis_sets_allowed: false
+
+    # # mGGA
+    # R2SCAN = "r2scan"
+    # R2SCAN3C = "r2scan3c"
+    # TPSS = "tpss"
+    # M06L = "m06l"
+    #
+    # # hybrid GGA
+    # PBE0 = "pbe0"
+    # B3LYP = "b3lyp"
+    # # B3PW91 = "b3pw91"
+    # # B97MV = "b97m_v"
+    #
+    # # hybrid mGGA
+    # TPSSH = "tpssh"
+    # M06 = "m06"
+    # M062X = "m062x"
+    #
+    # # range-separated
+    # CAMB3LYP = "camb3lyp"
+    # # WB97XD = "wb97x_d"
+    # WB97XD3 = "wb97x_d3"
+    # # WB97XD4 = "wb97x_d4"
+    # WB97XV = "wb97x_v"
+    # WB97MV = "wb97m_v"
+    # WB97MD3BJ = "wb97m_d3bj"
+    # WB97X3C = "wb97x_3c"
+    #
+    # # double hybrids
+    # DSD_BLYPD3BJ = "dsd_b3lyp_d3bj"
+    #
+    # # ML methods
+    # AIMNET2_WB97MD3 = "aimnet2_wb97md3"
+    # # AIMNET2_B973C = "aimnet2_b973c"
+    #
+    # # xTB methods
+    # # GFN0_XTB = "gfn1_xtb"
+    # GFN1_XTB = "gfn1_xtb"
+    # GFN2_XTB = "gfn2_xtb"
+    # GFN_FF = "gfn_ff"

--- a/stjames/settings.py
+++ b/stjames/settings.py
@@ -2,10 +2,10 @@ from typing import Any, Optional, TypeVar
 
 import pydantic
 
+from . import method
 from .base import Base, UniqueList
 from .basis_set import BasisSet
 from .correction import Correction
-from . import method
 from .mode import Mode
 from .opt_settings import OptimizationSettings
 from .scf_settings import SCFSettings

--- a/stjames/solvent.py
+++ b/stjames/solvent.py
@@ -32,6 +32,7 @@ class Solvent(LowercaseStrEnum):
 
 class SolventModel(LowercaseStrEnum):
     CPCM = "cpcm"
+    CPCMX = "cpcmx"
     ALPB = "alpb"
     COSMO = "cosmo"
 


### PR DESCRIPTION
This is my attempt to move methods from enum to objects - with the idea that we can more easily store configuration data, etc. I would love to be able to store the "names" of things in different QM programs so that we can use them wherever. 

I'm feeling a bit frustrated by this, and would love some advice @jevandezande. Part of the problem here is that I want to maintain data back-compatibility as much as possible, so that we can say {"method": "b3lyp"} etc and not completely break all of our existing records. This is a bit tricky though. Any thoughts? 